### PR TITLE
Launch Celeris via cmd or sh on Windows/WSL/Linux

### DIFF
--- a/scripts/run_linux.sh
+++ b/scripts/run_linux.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo "Shell script to launch Celeris-WebGPU on Linux (e.g. Ubuntu) using Chromium"
+echo ""
+echo "Look for chromium application on your system..."
+# sudo snap install chromium
+which chromium
+echo ""
+
+echo "Launch Chromium session for Celeris-WebGPU using common flags for hardware-acceleration and WebGPU..."  
+chromium https://plynett.github.io --ignore-gpu-blocklist --enable-unsafe-webgpu --enable-zero-copy  --enable-webgpu --enable-gpu-rasterization

--- a/scripts/run_windows.bat
+++ b/scripts/run_windows.bat
@@ -1,0 +1,16 @@
+@echo off
+echo Launch Celeris-WebGPU on Windows (Command Prompt --> Powershell --> Chrome)
+echo Find path to powershell.exe:
+where powershell.exe
+:: echo Find path to chrome.exe:
+:: for /f "usebackq tokens=1,2,3,4,5" %%a in (`reg query HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\ /s /f \chrome.exe ^| findstr Application`) do set CHROMEPATH=%%c
+:: echo %CHROMEPATH%
+echo Check for system's graphics processing unit (GPU)...
+wmic path win32_VideoController get name
+echo Check for NVIDIA GPU and NVIDIA Drivers...
+nvidia-smi
+:: echo Check if the Celeris-WebGPU github page is reachable...
+:: ping plynett.github.io
+:: tracert plynett.github.io
+:: Assuming both powershell.exe and chrome.exe exist, access the github live page for Celeris-WebGPU
+powershell.exe -ExecutionPolicy Bypass Start-Process chrome.exe --user-data-dir=C:\temp, https://plynett.github.io

--- a/scripts/run_wsl_linux.ps1
+++ b/scripts/run_wsl_linux.ps1
@@ -1,0 +1,2 @@
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass
+Start-Process chrome.exe -ArgumentList "--user-data-dir=C:\temp", "https://plynett.github.io"

--- a/scripts/run_wsl_linux.sh
+++ b/scripts/run_wsl_linux.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo ""
+echo "Launch Celeris-WebGPU as a chrome.exe instance from WSL2/Ubuntu using powershell.exe"
+echo "Avoids issues with GPU device detection for WebGPU acceleration."
+echo ""
+echo "Checking operating system..."
+uname -a
+lsb_release -a
+
+echo "Check for a NVIDIA GPU..."
+nvidia-smi
+glx-info | grep nvidia
+glx-info | grep display
+
+echo ""
+echo "Launch powershell.exe with scoped permissions..."
+powershell.exe -ExecutionPolicy Bypass -File run_wsl_linux.ps1


### PR DESCRIPTION
e.g.:

Windows 'cmd':
$  run_windows.bat

WSL terminal:
$  sh run_wsl_linux.sh

Linux terminal:
$  sh run_linux.sh

Note: Linux and WSL Linux are differentiated as their are often issues piping in control of the GPU to Chromium in WSL sessions, hence we call powershell.exe and chrome.exe on the Windows partition.

Note: Windows used '-ExecutionPolicy Bypass' to enable the process for the powershell.exe session, double-check if this is a security risk (might be preferred to use '-ExecutionPolicy unrestrict' as long as there is a closing '-ExecutionPolicy restrict' in the script)