### PR TITLE
Fix GPU memory leak: destroy staging buffers after texture upload

### DIFF
--- a/js/Copy_Data_to_Textures.js
+++ b/js/Copy_Data_to_Textures.js
@@ -84,6 +84,7 @@ function copyBathyDataToTexture(calc_constants, bathy2D, device, txBottom) {
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 
     return paddedFlatData;
 }
@@ -129,6 +130,7 @@ function copyWaveDataToTexture(calc_constants, waveData, device, txWaves) {
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 }
 
 
@@ -173,6 +175,7 @@ function copyTSlocsToTexture(calc_constants, device, txTimeSeries_Locations) {
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 }
 
 
@@ -235,6 +238,7 @@ function copyInitialConditionDataToTexture(calc_constants, device, initialState,
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 
 }
 
@@ -279,6 +283,7 @@ function copyConstantValueToTexture(calc_constants, device, txState, constantval
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 
 }
 
@@ -368,6 +373,7 @@ function copyTridiagXDataToTexture(calc_constants, bathy2D, device, coefMatx, ba
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 }
 
 function copyTridiagYDataToTexture(calc_constants, bathy2D, device, coefMaty, bathy2Dvec) {
@@ -455,6 +461,7 @@ function copyTridiagYDataToTexture(calc_constants, bathy2D, device, coefMaty, ba
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 }
 
 // This function will copy the ImageBitmap data directly into the texture.

--- a/transect_version/js/Copy_Data_to_Textures.js
+++ b/transect_version/js/Copy_Data_to_Textures.js
@@ -84,6 +84,7 @@ function copyBathyDataToTexture(calc_constants, bathy2D, device, txBottom) {
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 
     return paddedFlatData;
 }
@@ -126,6 +127,7 @@ function copyTransectWaveDataToTexture(calc_constants, waveData, device, txWaves
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 
 }
 
@@ -171,6 +173,7 @@ function copyWaveDataToTexture(calc_constants, waveData, device, txWaves) {
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 }
 
 
@@ -215,6 +218,7 @@ function copyTSlocsToTexture(calc_constants, device, txTimeSeries_Locations) {
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 }
 
 
@@ -269,6 +273,7 @@ function copyInitialConditionDataToTexture(calc_constants, device, bathy2D, txSt
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 
 }
 
@@ -313,6 +318,7 @@ function copyConstantValueToTexture(calc_constants, device, txState, constantval
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 
 }
 
@@ -402,6 +408,7 @@ function copyTridiagXDataToTexture(calc_constants, bathy2D, device, coefMatx, ba
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 }
 
 function copyTridiagYDataToTexture(calc_constants, bathy2D, device, coefMaty, bathy2Dvec) {
@@ -489,6 +496,7 @@ function copyTridiagYDataToTexture(calc_constants, bathy2D, device, coefMaty, ba
         depthOrArrayLayers: 1
     });
     device.queue.submit([commandEncoder.finish()]);
+    buffer.destroy();
 }
 
 // This function will copy the ImageBitmap data directly into the texture.


### PR DESCRIPTION
All buffer-to-texture copy functions in Copy_Data_to_Textures.js were creating GPUBuffers with mappedAtCreation but never calling buffer.destroy() after queue submission. Over long simulations this causes gradual GPU memory exhaustion, eventually crashing the WebGPU instance with "A valid external Instance reference no longer exists".

https://claude.ai/code/session_0137XvDojjup9bvSETTG7Gaz